### PR TITLE
Fix type of duration fields

### DIFF
--- a/specs/openapi-3.1.yaml
+++ b/specs/openapi-3.1.yaml
@@ -524,21 +524,21 @@ components:
           type: number
           description: Total duration of the request
         load_duration:
-          type: string
+          type: number
           description: Load duration of the request
         prompt_eval_count:
           type: integer
           description: Count of prompt evaluations
         prompt_eval_duration:
-          type: string
+          type: number
           description: Duration of prompt evaluations
         eval_count:
           type: integer
           description: Count of evaluations
         eval_duration:
-          type: string
+          type: number
           description: Duration of evaluations
-          
+
     CreateRequest:
       type: object
       description: Request to create a model


### PR DESCRIPTION
The duration fields returned by ollama API are large, nanosecond based integers